### PR TITLE
Add pydantic version to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ cohere==4.37
 openai==1.3.5
 tiktoken==0.5.1
 python-dotenv==1.0.0
+pydantic==2.10.1


### PR DESCRIPTION
Looks like pydantic had a breaking change that was incompatible with chainlit at some point, so I had to pin the pydantic version in the requirements file to get the challenge to work. Info here: https://github.com/Chainlit/chainlit/issues/1544

This PR just adds that to requirements.txt